### PR TITLE
Update composer.json to allow SS 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     },
     "require": {
         "php": ">=5.3",
-        "silverstripe/framework": "3.5.*",
-        "silverstripe/cms": "3.5.*",
+        "silverstripe/framework": "^3.5",
+        "silverstripe/cms": "^3.5",
         "aws/aws-sdk-php": "3.18"
     },
     "authors": [


### PR DESCRIPTION
Changing required cms and framework version to allow cms, frameword version 3.6 , Which is otherwise creating issues when using with current SilverStripe 3.6 installation 

Composer error

 Problem 1
    - Installation request for silverstripe/cms 3.6.1 -> satisfiable by silverstripe/cms[3.6.1].
    - fspringveldt/ss-easy-s3 dev-master requires silverstripe/cms 3.5.* -> satisfiable by silverstripe/cms[3.5.x-dev].
    - Can only install one of: silverstripe/cms[3.6.1, 3.5.x-dev].
    - Installation request for fspringveldt/ss-easy-s3 dev-master -> satisfiable by fspringveldt/ss-easy-s3[dev-master].